### PR TITLE
Fix/deb package fixes

### DIFF
--- a/src/pages/blog/posts/create-deb-package.md
+++ b/src/pages/blog/posts/create-deb-package.md
@@ -120,7 +120,7 @@ Congratulation, you have your signed package ! 👏
 
 ## 🗄️ How to create a mirror and authentify it
 
-### 🪞 Comment on créer le mirroir trivial
+### 🪞 How to create a simple mirror
 
 ---
 

--- a/src/pages/blog/posts/create-deb-package.md
+++ b/src/pages/blog/posts/create-deb-package.md
@@ -172,6 +172,33 @@ gpg --default-key [key_id] --clearsign -o InRelease Release
 
 Congratulation you've created your package along with your mirror and secured it ! 👏
 
+### 🔍 How is it done in real life
+
+In many cases you will only create `InRelease` and `Release` files because it is more recent and it cost less for apt.
+You can also create a `Release.gpg` file but it is the old way and it requires apt to do 2 requests to the server instead of one.
+
+Signing the package is not really used nowadays, it is more used to sign the Release file of the mirror.
+
+In example we can see down below how a mirror is often structured :
+
+```bash
+dists/
+└── stable/
+    ├── Release
+    ├── InRelease
+    └── main/
+        ├── binary-amd64/
+        │   └── Packages
+        ├── binary-i386/
+        │   └── Packages
+        └── source/
+            └── Sources
+```
+
+We can create multiple release for deferent programs and architectures, this is really useful when you want to distribute a lot of packages.
+As we can see we only have one file `Release` and `InRelease` for the whole mirror, this is because we are not going to sign the packages but only the release file.
+This is the most common way to create a mirror and distribute packages, it is also the way used by the official Debian and Ubuntu mirrors.
+
 ## 💚 Conclusion
 
 Creating a package can be useful in so much situations, this is one of the way to do it and manage your system but you have plenty of other ways to do so.


### PR DESCRIPTION
This pull request updates the blog post `create-deb-package.md` to improve clarity and provide additional information about creating and signing Debian package mirrors. The changes include rephrasing section titles for better readability and adding a detailed explanation of real-world practices for signing and structuring mirrors.

### Improvements to section clarity:

* [`src/pages/blog/posts/create-deb-package.md`](diffhunk://#diff-277ad6ffd5d29514b42a85a22ae563e7b7a226e08cab6a1f1cb76474ce1b855fL123-R123): Changed the section title from "Comment on créer le mirroir trivial" to "How to create a simple mirror" for consistency and readability in English.

### Additional information on real-world practices:

* [`src/pages/blog/posts/create-deb-package.md`](diffhunk://#diff-277ad6ffd5d29514b42a85a22ae563e7b7a226e08cab6a1f1cb76474ce1b855fR175-R201): Added a new section explaining how mirrors are structured in real-world scenarios, emphasizing the use of `Release` and `InRelease` files over signing individual packages. The section includes a sample directory structure and notes on efficiency and common practices in Debian and Ubuntu mirrors.