### PR TITLE
fix : Changed text to avoid css breaks

### DIFF
--- a/src/pages/blog/posts/create-deb-package.md
+++ b/src/pages/blog/posts/create-deb-package.md
@@ -133,7 +133,11 @@ cd /var/www/html/deb
 dpkg-scanpackages . /dev/null | gzip -9c > Packages.gz
 ```
 
-After doing so we can add the mirror to our sources on our system by modifying the file `/etc/apt/sources.list.d/[package].list` and putting
+After doing so we can add the mirror to our sources on our system by modifying the file 
+```
+/etc/apt/sources.list.d/[package].list
+``` 
+and putting
 
 ```bash
 deb [trusted=yes] http://localhost/deb ./


### PR DESCRIPTION
This pull request makes a small formatting improvement to the `src/pages/blog/posts/create-deb-package.md` file. The change ensures that the file path `/etc/apt/sources.list.d/[package].list` is displayed as a code block for better readability.